### PR TITLE
Change www-data user's UID and GID to 101 in the php-fpm images

### DIFF
--- a/php8.0-fpm/Dockerfile
+++ b/php8.0-fpm/Dockerfile
@@ -101,6 +101,12 @@ RUN { \
 
 ################################################################################
 
+# Change www-data user's UID and GID to 101 to match nginx user's UID and GID in the official nginx image.
+# https://hub.docker.com/_/nginx 
+# https://stackoverflow.com/questions/36824222/how-to-change-the-nginx-process-user-of-the-official-docker-image-nginx
+RUN usermod -u 101 -o www-data \
+	&& groupmod -g 101 -o www-data
+
 # Install extra package dependencies
 RUN apt-get update \
 	&& apt-get install --yes --no-install-recommends \

--- a/php8.1-fpm/Dockerfile
+++ b/php8.1-fpm/Dockerfile
@@ -101,6 +101,12 @@ RUN { \
 
 ################################################################################
 
+# Change www-data user's UID and GID to 101 to match nginx user's UID and GID in the official nginx image.
+# https://hub.docker.com/_/nginx 
+# https://stackoverflow.com/questions/36824222/how-to-change-the-nginx-process-user-of-the-official-docker-image-nginx
+RUN usermod -u 101 -o www-data \
+	&& groupmod -g 101 -o www-data
+
 # Install extra package dependencies
 RUN apt-get update \
 	&& apt-get install --yes --no-install-recommends \

--- a/php8.2-fpm/Dockerfile
+++ b/php8.2-fpm/Dockerfile
@@ -101,6 +101,12 @@ RUN { \
 
 ################################################################################
 
+# Change www-data user's UID and GID to 101 to match nginx user's UID and GID in the official nginx image.
+# https://hub.docker.com/_/nginx 
+# https://stackoverflow.com/questions/36824222/how-to-change-the-nginx-process-user-of-the-official-docker-image-nginx
+RUN usermod -u 101 -o www-data \
+	&& groupmod -g 101 -o www-data
+
 # Install extra package dependencies
 RUN apt-get update \
 	&& apt-get install --yes --no-install-recommends \


### PR DESCRIPTION
The UID / GID of the www-data user included in the php-fpm images is 33 / 33, while the UID / GID of the nginx user in the official Nginx image is 101 / 101.

> Since 1.17.0, both alpine- and debian-based images variants use the same user and group ids to drop the privileges for worker processes:
> 
> $ id
> uid=101(nginx) gid=101(nginx) groups=101(nginx)

Therefore, when the document root volume is mounted and shared, there can be permission errors when accessing static files, rather than owner permissions.

To avoid this, change the UID / GID of the www-data user to 101 / 101 during the build of the base image, to match that of the Nginx image.

This changes only apply to the following images (the latest versions of images that have php-fpm variants):

- kodansha/bedrock:php8.0-fpm
- kodansha/bedrock:php8.0.29-fpm
- ghcr.io/kodansha/bedrock:php8.0-fpm
- ghcr.io/kodansha/bedrock:php8.0.29-fpm
- kodansha/bedrock:php8.1-fpm
- kodansha/bedrock:php8.1.20-fpm
- ghcr.io/kodansha/bedrock:php8.1-fpm
- ghcr.io/kodansha/bedrock:php8.1.20-fpm
- kodansha/bedrock:php8.2-fpm
- kodansha/bedrock:php8.2.7-fpm
- ghcr.io/kodansha/bedrock:php8.2-fpm
- ghcr.io/kodansha/bedrock:php8.2.7-fpm


## References

- https://hub.docker.com/_/nginx
- https://stackoverflow.com/questions/36824222/how-to-change-the-nginx-process-user-of-the-official-docker-image-nginx
