### PR TITLE
Add PHP 8.3.1 images (without imagick)

### DIFF
--- a/.github/workflows/php8.3.yml
+++ b/.github/workflows/php8.3.yml
@@ -39,10 +39,10 @@ jobs:
           tags: |
             kodansha/bedrock:latest
             kodansha/bedrock:php8.3
-            kodansha/bedrock:php8.3.0
+            kodansha/bedrock:php8.3.1
             ghcr.io/kodansha/bedrock:latest
             ghcr.io/kodansha/bedrock:php8.3
-            ghcr.io/kodansha/bedrock:php8.3.0
+            ghcr.io/kodansha/bedrock:php8.3.1
 
       - name: Build and push PHP 8.3 (PHP-FPM) image
         uses: docker/build-push-action@v3
@@ -52,6 +52,6 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.3-fpm
-            kodansha/bedrock:php8.3.0-fpm
+            kodansha/bedrock:php8.3.1-fpm
             ghcr.io/kodansha/bedrock:php8.3-fpm
-            ghcr.io/kodansha/bedrock:php8.3.0-fpm
+            ghcr.io/kodansha/bedrock:php8.3.1-fpm

--- a/php8.3-fpm/Dockerfile
+++ b/php8.3-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3.0-fpm
+FROM php:8.3.1-fpm
 
 ################################################################################
 # From the official WordPress image
@@ -43,10 +43,11 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
-	rm -r /tmp/pear; \
+# https://github.com/Imagick/imagick/pull/641
+# # https://pecl.php.net/package/imagick
+# 	pecl install imagick-3.6.0; \
+# 	docker-php-ext-enable imagick; \
+ 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)
 	out="$(php -r 'exit(0);')"; \

--- a/php8.3/Dockerfile
+++ b/php8.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3.0-apache
+FROM php:8.3.1-apache
 
 ################################################################################
 # From the official WordPress image
@@ -43,9 +43,10 @@ RUN set -ex; \
 		mysqli \
 		zip \
 	; \
-# https://pecl.php.net/package/imagick
-	pecl install imagick-3.6.0; \
-	docker-php-ext-enable imagick; \
+# https://github.com/Imagick/imagick/pull/641
+# # https://pecl.php.net/package/imagick
+# 	pecl install imagick-3.6.0; \
+# 	docker-php-ext-enable imagick; \
 	rm -r /tmp/pear; \
 	\
 # some misbehaving extensions end up outputting to stdout 🙈 (https://github.com/docker-library/wordpress/issues/669#issuecomment-993945967)


### PR DESCRIPTION
Due to the cause mentioned in [this issue](https://github.com/Imagick/imagick/pull/641), I was unable to build the imagick extension with the PHP 8.3 base image, and therefore, I could not provide the PHP 8.3 docker-bedrock images.

However, as demands for the PHP 8.3 version are starting to arise, I have decided to create the images without configuring the imagick extension until the above problem is resolved.

This is because imagick is optional requirement for WordPress, and the GD extension satisfies the minimum functionality required.