### PR TITLE
Some update

### DIFF
--- a/php7.3/Dockerfile
+++ b/php7.3/Dockerfile
@@ -157,3 +157,7 @@ ENV APACHE_DOCUMENT_ROOT ${WEB_ROOT}/web
 # Replace webroot strings in Apache config files
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+# To run composer as root without any interaction
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_NO_INTERACTION 1

--- a/php7.4/Dockerfile
+++ b/php7.4/Dockerfile
@@ -157,3 +157,7 @@ ENV APACHE_DOCUMENT_ROOT ${WEB_ROOT}/web
 # Replace webroot strings in Apache config files
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+# To run composer as root without any interaction
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_NO_INTERACTION 1

--- a/php8.0-fpm/Dockerfile
+++ b/php8.0-fpm/Dockerfile
@@ -138,3 +138,7 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
 	&& chmod +x wp-cli.phar \
 	&& mv wp-cli.phar /usr/local/bin/wp \
 	&& wp --info
+
+# To run composer as root without any interaction
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_NO_INTERACTION 1

--- a/php8.0/Dockerfile
+++ b/php8.0/Dockerfile
@@ -158,3 +158,7 @@ ENV APACHE_DOCUMENT_ROOT ${WEB_ROOT}/web
 # Replace webroot strings in Apache config files
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+# To run composer as root without any interaction
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_NO_INTERACTION 1

--- a/php8.1-fpm/Dockerfile
+++ b/php8.1-fpm/Dockerfile
@@ -69,7 +69,7 @@ RUN set -ex; \
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
 	ldd "$extDir"/*.so \
-		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
 		| cut -d: -f1 \

--- a/php8.1-fpm/Dockerfile
+++ b/php8.1-fpm/Dockerfile
@@ -126,7 +126,7 @@ RUN apt-get update \
 	&& rm --recursive --force /var/lib/apt/lists/*
 
 # Install PHP extra extension
-RUN pecl install redis-5.3.7 \
+RUN pecl install redis-6.0.2 \
 	&& docker-php-ext-enable redis \
 	&& rm -r /tmp/pear
 

--- a/php8.1-fpm/Dockerfile
+++ b/php8.1-fpm/Dockerfile
@@ -147,3 +147,7 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
 	&& chmod +x wp-cli.phar \
 	&& mv wp-cli.phar /usr/local/bin/wp \
 	&& wp --info
+
+# To run composer as root without any interaction
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_NO_INTERACTION 1

--- a/php8.1/Dockerfile
+++ b/php8.1/Dockerfile
@@ -69,7 +69,7 @@ RUN set -ex; \
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
 	ldd "$extDir"/*.so \
-		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
 		| cut -d: -f1 \

--- a/php8.1/Dockerfile
+++ b/php8.1/Dockerfile
@@ -139,7 +139,7 @@ RUN apt-get update \
 	&& rm --recursive --force /var/lib/apt/lists/*
 
 # Install PHP extra extension
-RUN pecl install redis-5.3.7 \
+RUN pecl install redis-6.0.2 \
 	&& docker-php-ext-enable redis \
 	&& rm -r /tmp/pear
 

--- a/php8.1/Dockerfile
+++ b/php8.1/Dockerfile
@@ -167,3 +167,7 @@ ENV APACHE_DOCUMENT_ROOT ${WEB_ROOT}/web
 # Replace webroot strings in Apache config files
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+# To run composer as root without any interaction
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_NO_INTERACTION 1

--- a/php8.2-fpm/Dockerfile
+++ b/php8.2-fpm/Dockerfile
@@ -69,7 +69,7 @@ RUN set -ex; \
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
 	ldd "$extDir"/*.so \
-		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
 		| cut -d: -f1 \

--- a/php8.2-fpm/Dockerfile
+++ b/php8.2-fpm/Dockerfile
@@ -126,7 +126,7 @@ RUN apt-get update \
 	&& rm --recursive --force /var/lib/apt/lists/*
 
 # Install PHP extra extension
-RUN pecl install redis-5.3.7 \
+RUN pecl install redis-6.0.2 \
 	&& docker-php-ext-enable redis \
 	&& rm -r /tmp/pear
 

--- a/php8.2-fpm/Dockerfile
+++ b/php8.2-fpm/Dockerfile
@@ -147,3 +147,7 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
 	&& chmod +x wp-cli.phar \
 	&& mv wp-cli.phar /usr/local/bin/wp \
 	&& wp --info
+
+# To run composer as root without any interaction
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_NO_INTERACTION 1

--- a/php8.2/Dockerfile
+++ b/php8.2/Dockerfile
@@ -69,7 +69,7 @@ RUN set -ex; \
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
 	ldd "$extDir"/*.so \
-		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
 		| cut -d: -f1 \

--- a/php8.2/Dockerfile
+++ b/php8.2/Dockerfile
@@ -139,7 +139,7 @@ RUN apt-get update \
 	&& rm --recursive --force /var/lib/apt/lists/*
 
 # Install PHP extra extension
-RUN pecl install redis-5.3.7 \
+RUN pecl install redis-6.0.2 \
 	&& docker-php-ext-enable redis \
 	&& rm -r /tmp/pear
 

--- a/php8.2/Dockerfile
+++ b/php8.2/Dockerfile
@@ -167,3 +167,7 @@ ENV APACHE_DOCUMENT_ROOT ${WEB_ROOT}/web
 # Replace webroot strings in Apache config files
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+# To run composer as root without any interaction
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_NO_INTERACTION 1

--- a/php8.3-fpm/Dockerfile
+++ b/php8.3-fpm/Dockerfile
@@ -69,7 +69,7 @@ RUN set -ex; \
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
 	ldd "$extDir"/*.so \
-		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
 		| cut -d: -f1 \

--- a/php8.3-fpm/Dockerfile
+++ b/php8.3-fpm/Dockerfile
@@ -126,7 +126,7 @@ RUN apt-get update \
 	&& rm --recursive --force /var/lib/apt/lists/*
 
 # Install PHP extra extension
-RUN pecl install redis-5.3.7 \
+RUN pecl install redis-6.0.2 \
 	&& docker-php-ext-enable redis \
 	&& rm -r /tmp/pear
 

--- a/php8.3-fpm/Dockerfile
+++ b/php8.3-fpm/Dockerfile
@@ -147,3 +147,7 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
 	&& chmod +x wp-cli.phar \
 	&& mv wp-cli.phar /usr/local/bin/wp \
 	&& wp --info
+
+# To run composer as root without any interaction
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_NO_INTERACTION 1

--- a/php8.3/Dockerfile
+++ b/php8.3/Dockerfile
@@ -69,7 +69,7 @@ RUN set -ex; \
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark; \
 	ldd "$extDir"/*.so \
-		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
+		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); printf "*%s\n", so }' \
 		| sort -u \
 		| xargs -r dpkg-query --search \
 		| cut -d: -f1 \

--- a/php8.3/Dockerfile
+++ b/php8.3/Dockerfile
@@ -139,7 +139,7 @@ RUN apt-get update \
 	&& rm --recursive --force /var/lib/apt/lists/*
 
 # Install PHP extra extension
-RUN pecl install redis-5.3.7 \
+RUN pecl install redis-6.0.2 \
 	&& docker-php-ext-enable redis \
 	&& rm -r /tmp/pear
 

--- a/php8.3/Dockerfile
+++ b/php8.3/Dockerfile
@@ -167,3 +167,7 @@ ENV APACHE_DOCUMENT_ROOT ${WEB_ROOT}/web
 # Replace webroot strings in Apache config files
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+# To run composer as root without any interaction
+ENV COMPOSER_ALLOW_SUPERUSER 1
+ENV COMPOSER_NO_INTERACTION 1


### PR DESCRIPTION
- [apply wordpress official image upstream changes](https://github.com/kodansha/docker-bedrock/commit/29c75c3edf5b1b1952e7e536936147ad1a9f19a5)
  - Fix dpkg-query --search to be more specific
- [update redis extension to 6.0.2](https://github.com/kodansha/docker-bedrock/commit/fd7919dcec7e3f27a1aa51f0457403208dcfdbe9)
  - 6.0.0 has no breaking changes https://pecl.php.net/package-changelog.php?package=redis
- [add COMPOSER_ALLOW_SUPERUSER and COMPOSER_NO_INTERACTION to run composer as root without any interaction](https://github.com/kodansha/docker-bedrock/commit/f8f3153a0efff0a97131aff6c6b00af5c2385fbe)
  - when running as root, composer 2.7.0 prevent installing Wordpress core via composer by default