### PR TITLE
Images for PHP 8.4 and later will not install the Redis extension by default

### DIFF
--- a/features/src/bedrock-extra/README.md
+++ b/features/src/bedrock-extra/README.md
@@ -15,9 +15,11 @@ This feature enhances the developer experience by adding some additional tools a
 |-----|-----|-----|-----|-----|
 | locale | Install and configure the specified locale | string | none | ja_JP.UTF-8 |
 | xdebug | Whether to install Xdebug | boolean | false | true |
-| xdebugVersion | Xdebug version to install (effective only if `xdebug` is true) | string | latest | 3.3.0 |
+| xdebugVersion | Xdebug version to install (effective only if `xdebug` is true) | string | latest | 3.4.2 |
 | xdebugClientHost | Xdebug client host (effective only if `xdebug` is true) | string | localhost | host.docker.internal |
 | xdebugClientPort | Xdebug client port (effective only if `xdebug` is true) | string | 9003 | 9000 |
+| redis | Whether to install Redis | boolean | false | true |
+| redisVersion | Redis version to install (effective only if `redis` is true) | string | latest | 6.1.0 |
 
 ## Example Usage
 
@@ -25,14 +27,16 @@ This feature enhances the developer experience by adding some additional tools a
 {
     // ... other devcontainer.json settings
 
-    "image": "ghcr.io/kodansha/bedrock:php8.3-fpm",
+    "image": "ghcr.io/kodansha/bedrock:php8.4-fpm",
     "features": {
         "ghcr.io/kodansha/docker-bedrock/bedrock-extra:1": {
             "locale": "ja_JP.UTF-8",
             "xdebug": true,
-            "xdebugVersion": "3.3.0",
+            "xdebugVersion": "3.4.2",
             "xdebugClientHost": "host.docker.internal",
-            "xdebugClientPort": "9000"
+            "xdebugClientPort": "9000",
+            "redis": true,
+            "redisVersion": "6.1.0"
         }
     },
     "containerEnv": {

--- a/features/src/bedrock-extra/install.sh
+++ b/features/src/bedrock-extra/install.sh
@@ -7,6 +7,8 @@ OPTIONS_XDEBUG="${XDEBUG:-"false"}"
 OPTIONS_XDEBUG_VERSION="${XDEBUGVERSION:-"latest"}"
 OPTIONS_XDEBUG_CLIENT_HOST="${XDEBUGCLIENTHOST:-"localhost"}"
 OPTIONS_XDEBUG_CLIENT_PORT="${XDEBUGCLIENTPORT:-"9003"}"
+OPTIONS_REDIS="${REDIS:-"false"}"
+OPTIONS_REDIS_VERSION="${REDISVERSION:-"latest"}"
 
 # Install packages
 apt-get update && apt-get install -y \
@@ -21,7 +23,7 @@ if [ "$OPTIONS_LOCALE" != "none" ]; then
 fi
 
 # Xdebug installation
-if [ "$OPTIONS_XDEBUG" != "false" ]; then
+if [ "$OPTIONS_XDEBUG" = "true" ]; then
     if [ "$OPTIONS_XDEBUG_VERSION" != "latest" ]; then
         pecl install xdebug-${OPTIONS_XDEBUG_VERSION}
     else
@@ -37,4 +39,15 @@ xdebug.start_with_request=yes
 xdebug.client_host=${OPTIONS_XDEBUG_CLIENT_HOST}
 xdebug.client_port=${OPTIONS_XDEBUG_CLIENT_PORT}
 EOL
+fi
+
+# Redis installation
+if [ "$OPTIONS_REDIS" = "true" ]; then
+    if [ "$OPTIONS_REDIS_VERSION" != "latest" ]; then
+        pecl install redis-${OPTIONS_REDIS_VERSION}
+    else
+        pecl install redis
+    fi
+
+    docker-php-ext-enable redis
 fi

--- a/php8.4-fpm/Dockerfile
+++ b/php8.4-fpm/Dockerfile
@@ -119,11 +119,6 @@ RUN apt-get update \
 	&& apt-get clean \
 	&& rm --recursive --force /var/lib/apt/lists/*
 
-# Install PHP extra extension
-RUN pecl install redis-6.0.2 \
-	&& docker-php-ext-enable redis \
-	&& rm -r /tmp/pear
-
 # PHP custom configuration
 RUN { \
 	echo 'zend.exception_ignore_args = On'; \

--- a/php8.4/Dockerfile
+++ b/php8.4/Dockerfile
@@ -132,11 +132,6 @@ RUN apt-get update \
 	&& apt-get clean \
 	&& rm --recursive --force /var/lib/apt/lists/*
 
-# Install PHP extra extension
-RUN pecl install redis-6.0.2 \
-	&& docker-php-ext-enable redis \
-	&& rm -r /tmp/pear
-
 # PHP custom configuration
 RUN { \
 	echo 'zend.exception_ignore_args = On'; \


### PR DESCRIPTION
For images up to PHP 8.3, the Redis extension (PhpRedis) was included as part of the default configuration.

However, this approach has the following issues:

- The extension is installed even when Redis is not used, increasing the image size
- The Redis version depends on the one installed in the image

Therefore, starting from PHP 8.4, the Redis extension will not be installed.

If you need to install it, use one of the following methods:

- Install it in a Dockerfile based on the docker-bedrock base image
- If using a Dev Container, utilize the [bedrock-extra feature](https://github.com/kodansha/docker-bedrock/tree/main/features/src/bedrock-extra)