### PR TITLE
PHP 8.4.20, 8.5.5

### DIFF
--- a/.github/workflows/php8.4.yml
+++ b/.github/workflows/php8.4.yml
@@ -38,9 +38,9 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.4
-            kodansha/bedrock:php8.4.18
+            kodansha/bedrock:php8.4.20
             ghcr.io/kodansha/bedrock:php8.4
-            ghcr.io/kodansha/bedrock:php8.4.18
+            ghcr.io/kodansha/bedrock:php8.4.20
 
       - name: Build and push PHP 8.4 (PHP-FPM) image
         uses: docker/build-push-action@v3
@@ -50,6 +50,6 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.4-fpm
-            kodansha/bedrock:php8.4.18-fpm
+            kodansha/bedrock:php8.4.20-fpm
             ghcr.io/kodansha/bedrock:php8.4-fpm
-            ghcr.io/kodansha/bedrock:php8.4.18-fpm
+            ghcr.io/kodansha/bedrock:php8.4.20-fpm

--- a/.github/workflows/php8.5.yml
+++ b/.github/workflows/php8.5.yml
@@ -39,10 +39,10 @@ jobs:
           tags: |
             kodansha/bedrock:latest
             kodansha/bedrock:php8.5
-            kodansha/bedrock:php8.5.3
+            kodansha/bedrock:php8.5.5
             ghcr.io/kodansha/bedrock:latest
             ghcr.io/kodansha/bedrock:php8.5
-            ghcr.io/kodansha/bedrock:php8.5.3
+            ghcr.io/kodansha/bedrock:php8.5.5
 
       - name: Build and push PHP 8.5 (PHP-FPM) image
         uses: docker/build-push-action@v3
@@ -52,6 +52,6 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.5-fpm
-            kodansha/bedrock:php8.5.3-fpm
+            kodansha/bedrock:php8.5.5-fpm
             ghcr.io/kodansha/bedrock:php8.5-fpm
-            ghcr.io/kodansha/bedrock:php8.5.3-fpm
+            ghcr.io/kodansha/bedrock:php8.5.5-fpm

--- a/php8.4-fpm/Dockerfile
+++ b/php8.4-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4.18-fpm
+FROM php:8.4.20-fpm
 
 ################################################################################
 # From the official WordPress image

--- a/php8.4/Dockerfile
+++ b/php8.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4.18-apache
+FROM php:8.4.20-apache
 
 ################################################################################
 # From the official WordPress image

--- a/php8.5-fpm/Dockerfile
+++ b/php8.5-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.5.3-fpm
+FROM php:8.5.5-fpm
 
 ################################################################################
 # From the official WordPress image

--- a/php8.5/Dockerfile
+++ b/php8.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.5.3-apache
+FROM php:8.5.5-apache
 
 ################################################################################
 # From the official WordPress image


### PR DESCRIPTION
## Updated versions

- PHP 8.4: 8.4.18 → 8.4.20
- PHP 8.5: 8.5.3 → 8.5.5

## No changes

- PHP 8.2: already at 8.2.30 (no update)
- PHP 8.3: already at 8.3.30 (no update)