### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/php8.2.yml
+++ b/.github/workflows/php8.2.yml
@@ -8,30 +8,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
       - name: Build and push PHP 8.2 image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: ./php8.2
           platforms: linux/amd64,linux/arm64
@@ -43,7 +43,7 @@ jobs:
             ghcr.io/kodansha/bedrock:php8.2.31
 
       - name: Build and push PHP 8.2 (PHP-FPM) image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: ./php8.2-fpm
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/php8.3.yml
+++ b/.github/workflows/php8.3.yml
@@ -8,30 +8,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
       - name: Build and push PHP 8.3 image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: ./php8.3
           platforms: linux/amd64,linux/arm64
@@ -43,7 +43,7 @@ jobs:
             ghcr.io/kodansha/bedrock:php8.3.31
 
       - name: Build and push PHP 8.3 (PHP-FPM) image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: ./php8.3-fpm
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/php8.4.yml
+++ b/.github/workflows/php8.4.yml
@@ -8,30 +8,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
       - name: Build and push PHP 8.4 image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: ./php8.4
           platforms: linux/amd64,linux/arm64
@@ -43,7 +43,7 @@ jobs:
             ghcr.io/kodansha/bedrock:php8.4.21
 
       - name: Build and push PHP 8.4 (PHP-FPM) image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: ./php8.4-fpm
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/php8.5.yml
+++ b/.github/workflows/php8.5.yml
@@ -8,30 +8,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
 
       - name: Build and push PHP 8.5 image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: ./php8.5
           platforms: linux/amd64,linux/arm64
@@ -45,7 +45,7 @@ jobs:
             ghcr.io/kodansha/bedrock:php8.5.6
 
       - name: Build and push PHP 8.5 (PHP-FPM) image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           context: ./php8.5-fpm
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary

Update GitHub Actions used in PHP 8.2, 8.3, 8.4, and 8.5 workflows to their latest major versions.

- `actions/checkout`: v3 → v6
- `docker/setup-qemu-action`: v2 → v4
- `docker/setup-buildx-action`: v2 → v4
- `docker/login-action`: v2 → v4
- `docker/build-push-action`: v3 → v7

All existing parameters (`platforms`, `push`, `tags`, `context`, `registry`, `username`, `password`) remain fully compatible with the latest versions.