### PR TITLE
PHP 8.2.32, 8.3.32, 8.4.23, 8.5.7

### DIFF
--- a/.claude/skills/update-bedrock-images/SKILL.md
+++ b/.claude/skills/update-bedrock-images/SKILL.md
@@ -90,6 +90,8 @@ If there are updates, review the diff. **Never reformat Dockerfiles.**
 
 ### 5. Commit
 
+**Before committing, verify the current branch is the topic branch created in step 3, not `main`** (`git branch --show-current`). Never commit directly to `main`.
+
 Stage all changed files and commit.
 List the updated PHP versions in the commit message, separated by commas.
 

--- a/.github/workflows/php8.2.yml
+++ b/.github/workflows/php8.2.yml
@@ -38,9 +38,9 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.2
-            kodansha/bedrock:php8.2.31
+            kodansha/bedrock:php8.2.32
             ghcr.io/kodansha/bedrock:php8.2
-            ghcr.io/kodansha/bedrock:php8.2.31
+            ghcr.io/kodansha/bedrock:php8.2.32
 
       - name: Build and push PHP 8.2 (PHP-FPM) image
         uses: docker/build-push-action@v7
@@ -50,6 +50,6 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.2-fpm
-            kodansha/bedrock:php8.2.31-fpm
+            kodansha/bedrock:php8.2.32-fpm
             ghcr.io/kodansha/bedrock:php8.2-fpm
-            ghcr.io/kodansha/bedrock:php8.2.31-fpm
+            ghcr.io/kodansha/bedrock:php8.2.32-fpm

--- a/.github/workflows/php8.3.yml
+++ b/.github/workflows/php8.3.yml
@@ -38,9 +38,9 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.3
-            kodansha/bedrock:php8.3.31
+            kodansha/bedrock:php8.3.32
             ghcr.io/kodansha/bedrock:php8.3
-            ghcr.io/kodansha/bedrock:php8.3.31
+            ghcr.io/kodansha/bedrock:php8.3.32
 
       - name: Build and push PHP 8.3 (PHP-FPM) image
         uses: docker/build-push-action@v7
@@ -50,6 +50,6 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.3-fpm
-            kodansha/bedrock:php8.3.31-fpm
+            kodansha/bedrock:php8.3.32-fpm
             ghcr.io/kodansha/bedrock:php8.3-fpm
-            ghcr.io/kodansha/bedrock:php8.3.31-fpm
+            ghcr.io/kodansha/bedrock:php8.3.32-fpm

--- a/.github/workflows/php8.4.yml
+++ b/.github/workflows/php8.4.yml
@@ -38,9 +38,9 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.4
-            kodansha/bedrock:php8.4.21
+            kodansha/bedrock:php8.4.23
             ghcr.io/kodansha/bedrock:php8.4
-            ghcr.io/kodansha/bedrock:php8.4.21
+            ghcr.io/kodansha/bedrock:php8.4.23
 
       - name: Build and push PHP 8.4 (PHP-FPM) image
         uses: docker/build-push-action@v7
@@ -50,6 +50,6 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.4-fpm
-            kodansha/bedrock:php8.4.21-fpm
+            kodansha/bedrock:php8.4.23-fpm
             ghcr.io/kodansha/bedrock:php8.4-fpm
-            ghcr.io/kodansha/bedrock:php8.4.21-fpm
+            ghcr.io/kodansha/bedrock:php8.4.23-fpm

--- a/.github/workflows/php8.5.yml
+++ b/.github/workflows/php8.5.yml
@@ -39,10 +39,10 @@ jobs:
           tags: |
             kodansha/bedrock:latest
             kodansha/bedrock:php8.5
-            kodansha/bedrock:php8.5.6
+            kodansha/bedrock:php8.5.7
             ghcr.io/kodansha/bedrock:latest
             ghcr.io/kodansha/bedrock:php8.5
-            ghcr.io/kodansha/bedrock:php8.5.6
+            ghcr.io/kodansha/bedrock:php8.5.7
 
       - name: Build and push PHP 8.5 (PHP-FPM) image
         uses: docker/build-push-action@v7
@@ -52,6 +52,6 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.5-fpm
-            kodansha/bedrock:php8.5.6-fpm
+            kodansha/bedrock:php8.5.7-fpm
             ghcr.io/kodansha/bedrock:php8.5-fpm
-            ghcr.io/kodansha/bedrock:php8.5.6-fpm
+            ghcr.io/kodansha/bedrock:php8.5.7-fpm

--- a/php8.2-fpm/Dockerfile
+++ b/php8.2-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2.31-fpm
+FROM php:8.2.32-fpm
 
 ################################################################################
 # From the official WordPress image

--- a/php8.2/Dockerfile
+++ b/php8.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2.31-apache
+FROM php:8.2.32-apache
 
 ################################################################################
 # From the official WordPress image

--- a/php8.3-fpm/Dockerfile
+++ b/php8.3-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3.31-fpm
+FROM php:8.3.32-fpm
 
 ################################################################################
 # From the official WordPress image

--- a/php8.3/Dockerfile
+++ b/php8.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3.31-apache
+FROM php:8.3.32-apache
 
 ################################################################################
 # From the official WordPress image

--- a/php8.4-fpm/Dockerfile
+++ b/php8.4-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4.21-fpm
+FROM php:8.4.23-fpm
 
 ################################################################################
 # From the official WordPress image

--- a/php8.4/Dockerfile
+++ b/php8.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4.21-apache
+FROM php:8.4.23-apache
 
 ################################################################################
 # From the official WordPress image

--- a/php8.5-fpm/Dockerfile
+++ b/php8.5-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.5.6-fpm
+FROM php:8.5.7-fpm
 
 ################################################################################
 # From the official WordPress image

--- a/php8.5/Dockerfile
+++ b/php8.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.5.6-apache
+FROM php:8.5.7-apache
 
 ################################################################################
 # From the official WordPress image


### PR DESCRIPTION
## Summary
- PHP 8.2: 8.2.31 → 8.2.32
- PHP 8.3: 8.3.31 → 8.3.32
- PHP 8.4: 8.4.21 → 8.4.23
- PHP 8.5: 8.5.6 → 8.5.7

Updated Dockerfiles (Apache/FPM) and GitHub Actions workflow image tags for all target PHP versions.