### PR TITLE
PHP 8.5.8

### DIFF
--- a/.github/workflows/php8.5.yml
+++ b/.github/workflows/php8.5.yml
@@ -39,10 +39,10 @@ jobs:
           tags: |
             kodansha/bedrock:latest
             kodansha/bedrock:php8.5
-            kodansha/bedrock:php8.5.7
+            kodansha/bedrock:php8.5.8
             ghcr.io/kodansha/bedrock:latest
             ghcr.io/kodansha/bedrock:php8.5
-            ghcr.io/kodansha/bedrock:php8.5.7
+            ghcr.io/kodansha/bedrock:php8.5.8
 
       - name: Build and push PHP 8.5 (PHP-FPM) image
         uses: docker/build-push-action@v7
@@ -52,6 +52,6 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.5-fpm
-            kodansha/bedrock:php8.5.7-fpm
+            kodansha/bedrock:php8.5.8-fpm
             ghcr.io/kodansha/bedrock:php8.5-fpm
-            ghcr.io/kodansha/bedrock:php8.5.7-fpm
+            ghcr.io/kodansha/bedrock:php8.5.8-fpm

--- a/php8.5-fpm/Dockerfile
+++ b/php8.5-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.5.7-fpm
+FROM php:8.5.8-fpm
 
 ################################################################################
 # From the official WordPress image

--- a/php8.5/Dockerfile
+++ b/php8.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.5.7-apache
+FROM php:8.5.8-apache
 
 ################################################################################
 # From the official WordPress image


### PR DESCRIPTION
## Summary
- Updated PHP 8.5 (Apache and FPM) base images from 8.5.7 to 8.5.8
- PHP 8.2, 8.3, 8.4 were already at the latest version — no changes needed