### PR TITLE
PHP 8.2.33, 8.3.33, 8.4.24, 8.5.9

### DIFF
--- a/.github/workflows/php8.2.yml
+++ b/.github/workflows/php8.2.yml
@@ -38,9 +38,9 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.2
-            kodansha/bedrock:php8.2.32
+            kodansha/bedrock:php8.2.33
             ghcr.io/kodansha/bedrock:php8.2
-            ghcr.io/kodansha/bedrock:php8.2.32
+            ghcr.io/kodansha/bedrock:php8.2.33
 
       - name: Build and push PHP 8.2 (PHP-FPM) image
         uses: docker/build-push-action@v7
@@ -50,6 +50,6 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.2-fpm
-            kodansha/bedrock:php8.2.32-fpm
+            kodansha/bedrock:php8.2.33-fpm
             ghcr.io/kodansha/bedrock:php8.2-fpm
-            ghcr.io/kodansha/bedrock:php8.2.32-fpm
+            ghcr.io/kodansha/bedrock:php8.2.33-fpm

--- a/.github/workflows/php8.3.yml
+++ b/.github/workflows/php8.3.yml
@@ -38,9 +38,9 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.3
-            kodansha/bedrock:php8.3.32
+            kodansha/bedrock:php8.3.33
             ghcr.io/kodansha/bedrock:php8.3
-            ghcr.io/kodansha/bedrock:php8.3.32
+            ghcr.io/kodansha/bedrock:php8.3.33
 
       - name: Build and push PHP 8.3 (PHP-FPM) image
         uses: docker/build-push-action@v7
@@ -50,6 +50,6 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.3-fpm
-            kodansha/bedrock:php8.3.32-fpm
+            kodansha/bedrock:php8.3.33-fpm
             ghcr.io/kodansha/bedrock:php8.3-fpm
-            ghcr.io/kodansha/bedrock:php8.3.32-fpm
+            ghcr.io/kodansha/bedrock:php8.3.33-fpm

--- a/.github/workflows/php8.4.yml
+++ b/.github/workflows/php8.4.yml
@@ -38,9 +38,9 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.4
-            kodansha/bedrock:php8.4.23
+            kodansha/bedrock:php8.4.24
             ghcr.io/kodansha/bedrock:php8.4
-            ghcr.io/kodansha/bedrock:php8.4.23
+            ghcr.io/kodansha/bedrock:php8.4.24
 
       - name: Build and push PHP 8.4 (PHP-FPM) image
         uses: docker/build-push-action@v7
@@ -50,6 +50,6 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.4-fpm
-            kodansha/bedrock:php8.4.23-fpm
+            kodansha/bedrock:php8.4.24-fpm
             ghcr.io/kodansha/bedrock:php8.4-fpm
-            ghcr.io/kodansha/bedrock:php8.4.23-fpm
+            ghcr.io/kodansha/bedrock:php8.4.24-fpm

--- a/.github/workflows/php8.5.yml
+++ b/.github/workflows/php8.5.yml
@@ -39,10 +39,10 @@ jobs:
           tags: |
             kodansha/bedrock:latest
             kodansha/bedrock:php8.5
-            kodansha/bedrock:php8.5.8
+            kodansha/bedrock:php8.5.9
             ghcr.io/kodansha/bedrock:latest
             ghcr.io/kodansha/bedrock:php8.5
-            ghcr.io/kodansha/bedrock:php8.5.8
+            ghcr.io/kodansha/bedrock:php8.5.9
 
       - name: Build and push PHP 8.5 (PHP-FPM) image
         uses: docker/build-push-action@v7
@@ -52,6 +52,6 @@ jobs:
           push: true
           tags: |
             kodansha/bedrock:php8.5-fpm
-            kodansha/bedrock:php8.5.8-fpm
+            kodansha/bedrock:php8.5.9-fpm
             ghcr.io/kodansha/bedrock:php8.5-fpm
-            ghcr.io/kodansha/bedrock:php8.5.8-fpm
+            ghcr.io/kodansha/bedrock:php8.5.9-fpm

--- a/php8.2-fpm/Dockerfile
+++ b/php8.2-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2.32-fpm
+FROM php:8.2.33-fpm
 
 ################################################################################
 # From the official WordPress image

--- a/php8.2/Dockerfile
+++ b/php8.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2.32-apache
+FROM php:8.2.33-apache
 
 ################################################################################
 # From the official WordPress image

--- a/php8.3-fpm/Dockerfile
+++ b/php8.3-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3.32-fpm
+FROM php:8.3.33-fpm
 
 ################################################################################
 # From the official WordPress image

--- a/php8.3/Dockerfile
+++ b/php8.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3.32-apache
+FROM php:8.3.33-apache
 
 ################################################################################
 # From the official WordPress image

--- a/php8.4-fpm/Dockerfile
+++ b/php8.4-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4.23-fpm
+FROM php:8.4.24-fpm
 
 ################################################################################
 # From the official WordPress image

--- a/php8.4/Dockerfile
+++ b/php8.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4.23-apache
+FROM php:8.4.24-apache
 
 ################################################################################
 # From the official WordPress image

--- a/php8.5-fpm/Dockerfile
+++ b/php8.5-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.5.8-fpm
+FROM php:8.5.9-fpm
 
 ################################################################################
 # From the official WordPress image

--- a/php8.5/Dockerfile
+++ b/php8.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.5.8-apache
+FROM php:8.5.9-apache
 
 ################################################################################
 # From the official WordPress image


### PR DESCRIPTION
## Summary
- PHP 8.2: 8.2.32 → 8.2.33
- PHP 8.3: 8.3.32 → 8.3.33
- PHP 8.4: 8.4.23 → 8.4.24
- PHP 8.5: 8.5.8 → 8.5.9

Updates Dockerfiles (Apache and FPM variants) and GitHub Actions workflow image tags for all non-EOSL PHP versions.